### PR TITLE
Resolve: MPI has no more C++ binding

### DIFF
--- a/src/common/utils/ToMPIDatatype.h
+++ b/src/common/utils/ToMPIDatatype.h
@@ -15,6 +15,19 @@
 
 #include <mpi.h>
 
+inline int MPI_get_rank()
+{
+	int rank;
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank)
+	return rank;
+}
+inline int MPI_get_size()
+{
+	int size;
+	MPI_Comm_size(MPI_COMM_WORLD, &size)
+	return size;
+}
+
 template<typename T>
 class ToMPIDatatype {
 public:

--- a/src/common/utils/ToMPIDatatype.h
+++ b/src/common/utils/ToMPIDatatype.h
@@ -18,13 +18,13 @@
 inline int MPI_get_rank()
 {
 	int rank;
-	MPI_Comm_rank(MPI_COMM_WORLD, &rank)
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 	return rank;
 }
 inline int MPI_get_size()
 {
 	int size;
-	MPI_Comm_size(MPI_COMM_WORLD, &size)
+	MPI_Comm_size(MPI_COMM_WORLD, &size);
 	return size;
 }
 

--- a/src/common/utils/ToMPIDatatype.h
+++ b/src/common/utils/ToMPIDatatype.h
@@ -18,26 +18,26 @@
 template<typename T>
 class ToMPIDatatype {
 public:
-	static inline MPI::Datatype value();
+	static inline MPI_Datatype value();
 };
 
 template<>
-inline MPI::Datatype ToMPIDatatype<double>::value() {
+inline MPI_Datatype ToMPIDatatype<double>::value() {
 	return MPI_DOUBLE;
 }
 
 template<>
-inline MPI::Datatype ToMPIDatatype<float>::value() {
+inline MPI_Datatype ToMPIDatatype<float>::value() {
 	return MPI_FLOAT;
 }
 
 template<>
-inline MPI::Datatype ToMPIDatatype<long>::value() {
+inline MPI_Datatype ToMPIDatatype<long>::value() {
 	return MPI_LONG;
 }
 
 template<>
-inline MPI::Datatype ToMPIDatatype<int>::value() {
+inline MPI_Datatype ToMPIDatatype<int>::value() {
 	return MPI_INTEGER;
 }
 

--- a/src/murb/core/collisionless/SimulationNBodyMPI.cpp
+++ b/src/murb/core/collisionless/SimulationNBodyMPI.cpp
@@ -66,25 +66,25 @@ void SimulationNBodyMPI<T>::init()
 	Bodies<T> *bBuffs[] = {&this->MPIBodiesBuffers[0], &this->MPIBodiesBuffers[1]};
 
 	// send number of bodies
-	MPI_Send_init(&bBuffs[0]->n,            1, MPI_LONG, MPINextRank, 0), MPI_COMM_WORLD, &this->MPIRequests[0][0];
-	MPI_Send_init(&bBuffs[1]->n,            1, MPI_LONG, MPINextRank, 1), MPI_COMM_WORLD, &this->MPIRequests[1][0];
+	MPI_Send_init(&bBuffs[0]->n,            1, MPI_LONG, MPINextRank, 0, MPI_COMM_WORLD, &this->MPIRequests[0][0]);
+	MPI_Send_init(&bBuffs[1]->n,            1, MPI_LONG, MPINextRank, 1, MPI_COMM_WORLD, &this->MPIRequests[1][0]);
 	// receive number of bodies
-	MPI_Recv_init(&bBuffs[1]->n,            1, MPI_LONG, MPIPrevRank, 0), MPI_COMM_WORLD, &this->MPIRequests[0][1];
-	MPI_Recv_init(&bBuffs[0]->n,            1, MPI_LONG, MPIPrevRank, 1), MPI_COMM_WORLD, &this->MPIRequests[1][1];
+	MPI_Recv_init(&bBuffs[1]->n,            1, MPI_LONG, MPIPrevRank, 0, MPI_COMM_WORLD, &this->MPIRequests[0][1]);
+	MPI_Recv_init(&bBuffs[0]->n,            1, MPI_LONG, MPIPrevRank, 1, MPI_COMM_WORLD, &this->MPIRequests[1][1]);
 
 	// send masses
-	MPI_Send_init(bBuffs[0]->masses,        n, MPIType,  MPINextRank, 2), MPI_COMM_WORLD, &this->MPIRequests[0][2];
-	MPI_Send_init(bBuffs[1]->masses,        n, MPIType,  MPINextRank, 3), MPI_COMM_WORLD, &this->MPIRequests[1][2];
+	MPI_Send_init(bBuffs[0]->masses,        n, MPIType,  MPINextRank, 2, MPI_COMM_WORLD, &this->MPIRequests[0][2]);
+	MPI_Send_init(bBuffs[1]->masses,        n, MPIType,  MPINextRank, 3, MPI_COMM_WORLD, &this->MPIRequests[1][2]);
 	// receive masses
-	MPI_Recv_init(bBuffs[1]->masses,        n, MPIType,  MPIPrevRank, 2), MPI_COMM_WORLD, &this->MPIRequests[0][3];
-	MPI_Recv_init(bBuffs[0]->masses,        n, MPIType,  MPIPrevRank, 3), MPI_COMM_WORLD, &this->MPIRequests[1][3];
+	MPI_Recv_init(bBuffs[1]->masses,        n, MPIType,  MPIPrevRank, 2, MPI_COMM_WORLD, &this->MPIRequests[0][3]);
+	MPI_Recv_init(bBuffs[0]->masses,        n, MPIType,  MPIPrevRank, 3, MPI_COMM_WORLD, &this->MPIRequests[1][3]);
 
 	// send radiuses
-	MPI_Send_init(bBuffs[0]->radiuses,      n, MPIType,  MPINextRank, 4), MPI_COMM_WORLD, &this->MPIRequests[0][4];
-	MPI_Send_init(bBuffs[1]->radiuses,      n, MPIType,  MPINextRank, 5), MPI_COMM_WORLD, &this->MPIRequests[1][4];
+	MPI_Send_init(bBuffs[0]->radiuses,      n, MPIType,  MPINextRank, 4, MPI_COMM_WORLD, &this->MPIRequests[0][4]);
+	MPI_Send_init(bBuffs[1]->radiuses,      n, MPIType,  MPINextRank, 5, MPI_COMM_WORLD, &this->MPIRequests[1][4]);
 	// receive radiuses
-	MPI_Recv_init(bBuffs[1]->radiuses,      n, MPIType,  MPIPrevRank, 4), MPI_COMM_WORLD, &this->MPIRequests[0][5];
-	MPI_Recv_init(bBuffs[0]->radiuses,      n, MPIType,  MPIPrevRank, 5), MPI_COMM_WORLD, &this->MPIRequests[1][5];
+	MPI_Recv_init(bBuffs[1]->radiuses,      n, MPIType,  MPIPrevRank, 4, MPI_COMM_WORLD, &this->MPIRequests[0][5]);
+	MPI_Recv_init(bBuffs[0]->radiuses,      n, MPIType,  MPIPrevRank, 5, MPI_COMM_WORLD, &this->MPIRequests[1][5]);
 
 	// send positions.x
 	MPI_Send_init(bBuffs[0]->positions.x,   n, MPIType,  MPINextRank, 6, MPI_COMM_WORLD, &this->MPIRequests[0][6]);

--- a/src/murb/core/collisionless/SimulationNBodyMPI.cpp
+++ b/src/murb/core/collisionless/SimulationNBodyMPI.cpp
@@ -31,16 +31,16 @@ inline int  omp_get_thread_num (   ) { return 0; }
 
 #include "SimulationNBodyMPI.h"
 
-MPIRank get_rank()
+int get_rank()
 {
-	MPIRank rank;
-	MPI_Comm_rank(MPI_COMM_WORLD, &rank)
+	int rank;
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 	return rank;
 }
-MPISize get_size()
+int get_size()
 {
-	MPISize size;
-	MPI_Comm_size(MPI_COMM_WORLD, &size)
+	int size;
+	MPI_Comm_size(MPI_COMM_WORLD, &size);
 	return size;
 }
 
@@ -158,20 +158,20 @@ void SimulationNBodyMPI<T>::computeOneIteration()
 	this->initIteration();
 
 	// compute bodies acceleration ------------------------------------------------------------------------------------
-	MPI_Prequest::Startall(2*9, this->MPIRequests[0]);
+	MPI_Startall(2*9, this->MPIRequests[0]);
 
 	this->computeLocalBodiesAcceleration();
  
 	for(int iStep = 1; iStep < this->MPISize; ++iStep)
 	{
-		MPI_Request::Waitall(2*9, this->MPIRequests[(iStep -1) % 2]);
+		MPI_Waitall(2*9, this->MPIRequests[(iStep -1) % 2], MPI_STATUSES_IGNORE);
 
 		this->neighborBodies = &this->MPIBodiesBuffers[iStep % 2];
 
 		this->computeNeighborBodiesAcceleration();
 
 		if(iStep < this->MPISize -1)
-			MPI_Prequest::Startall(2*9, this->MPIRequests[iStep % 2]);
+			MPI_Startall(2*9, this->MPIRequests[iStep % 2]);
 	}
 	// ----------------------------------------------------------------------------------------------------------------
 

--- a/src/murb/core/collisionless/SimulationNBodyMPI.cpp
+++ b/src/murb/core/collisionless/SimulationNBodyMPI.cpp
@@ -31,27 +31,13 @@ inline int  omp_get_thread_num (   ) { return 0; }
 
 #include "SimulationNBodyMPI.h"
 
-int get_rank()
-{
-	int rank;
-	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-	return rank;
-}
-int get_size()
-{
-	int size;
-	MPI_Comm_size(MPI_COMM_WORLD, &size);
-	return size;
-}
-
-
 
 template <typename T>
 SimulationNBodyMPI<T>::SimulationNBodyMPI(const unsigned long nBodies)
-	: SimulationNBody<T>(new Bodies<T>(nBodies, get_rank() * nBodies +1)),
+	: SimulationNBody<T>(new Bodies<T>(nBodies, MPI_get_rank() * nBodies +1)),
 	  neighborBodies    (NULL),
-	  MPISize           (get_size()),
-	  MPIRank           (get_rank()),
+	  MPISize           (MPI_get_size()),
+	  MPIRank           (MPI_get_rank()),
 	  MPIBodiesBuffers  {this->bodies->getN(), this->bodies->getN()}
 {
 	this->init();
@@ -61,8 +47,8 @@ template <typename T>
 SimulationNBodyMPI<T>::SimulationNBodyMPI(const std::string inputFileName)
 	: SimulationNBody<T>(new Bodies<T>(inputFileName)),
 	  neighborBodies    (NULL),
-	  MPISize           (get_size()),
-	  MPIRank           (get_rank()),
+	  MPISize           (MPI_get_size()),
+	  MPIRank           (MPI_get_rank()),
 	  MPIBodiesBuffers  {this->bodies->getN(), this->bodies->getN()}
 {
 	this->init();

--- a/src/murb/core/collisionless/SimulationNBodyMPI.cpp
+++ b/src/murb/core/collisionless/SimulationNBodyMPI.cpp
@@ -66,67 +66,67 @@ void SimulationNBodyMPI<T>::init()
 	Bodies<T> *bBuffs[] = {&this->MPIBodiesBuffers[0], &this->MPIBodiesBuffers[1]};
 
 	// send number of bodies
-	this->MPIRequests[0][0] = MPI_Send_init(&bBuffs[0]->n,            1, MPI_LONG, MPINextRank, 0);
-	this->MPIRequests[1][0] = MPI_Send_init(&bBuffs[1]->n,            1, MPI_LONG, MPINextRank, 1);
+	MPI_Send_init(&bBuffs[0]->n,            1, MPI_LONG, MPINextRank, 0), MPI_COMM_WORLD, &this->MPIRequests[0][0];
+	MPI_Send_init(&bBuffs[1]->n,            1, MPI_LONG, MPINextRank, 1), MPI_COMM_WORLD, &this->MPIRequests[1][0];
 	// receive number of bodies
-	this->MPIRequests[0][1] = MPI_Recv_init(&bBuffs[1]->n,            1, MPI_LONG, MPIPrevRank, 0);
-	this->MPIRequests[1][1] = MPI_Recv_init(&bBuffs[0]->n,            1, MPI_LONG, MPIPrevRank, 1);
+	MPI_Recv_init(&bBuffs[1]->n,            1, MPI_LONG, MPIPrevRank, 0), MPI_COMM_WORLD, &this->MPIRequests[0][1];
+	MPI_Recv_init(&bBuffs[0]->n,            1, MPI_LONG, MPIPrevRank, 1), MPI_COMM_WORLD, &this->MPIRequests[1][1];
 
 	// send masses
-	this->MPIRequests[0][2] = MPI_Send_init(bBuffs[0]->masses,        n, MPIType,  MPINextRank, 2);
-	this->MPIRequests[1][2] = MPI_Send_init(bBuffs[1]->masses,        n, MPIType,  MPINextRank, 3);
+	MPI_Send_init(bBuffs[0]->masses,        n, MPIType,  MPINextRank, 2), MPI_COMM_WORLD, &this->MPIRequests[0][2];
+	MPI_Send_init(bBuffs[1]->masses,        n, MPIType,  MPINextRank, 3), MPI_COMM_WORLD, &this->MPIRequests[1][2];
 	// receive masses
-	this->MPIRequests[0][3] = MPI_Recv_init(bBuffs[1]->masses,        n, MPIType,  MPIPrevRank, 2);
-	this->MPIRequests[1][3] = MPI_Recv_init(bBuffs[0]->masses,        n, MPIType,  MPIPrevRank, 3);
+	MPI_Recv_init(bBuffs[1]->masses,        n, MPIType,  MPIPrevRank, 2), MPI_COMM_WORLD, &this->MPIRequests[0][3];
+	MPI_Recv_init(bBuffs[0]->masses,        n, MPIType,  MPIPrevRank, 3), MPI_COMM_WORLD, &this->MPIRequests[1][3];
 
 	// send radiuses
-	this->MPIRequests[0][4] = MPI_Send_init(bBuffs[0]->radiuses,      n, MPIType,  MPINextRank, 4);
-	this->MPIRequests[1][4] = MPI_Send_init(bBuffs[1]->radiuses,      n, MPIType,  MPINextRank, 5);
+	MPI_Send_init(bBuffs[0]->radiuses,      n, MPIType,  MPINextRank, 4), MPI_COMM_WORLD, &this->MPIRequests[0][4];
+	MPI_Send_init(bBuffs[1]->radiuses,      n, MPIType,  MPINextRank, 5), MPI_COMM_WORLD, &this->MPIRequests[1][4];
 	// receive radiuses
-	this->MPIRequests[0][5] = MPI_Recv_init(bBuffs[1]->radiuses,      n, MPIType,  MPIPrevRank, 4);
-	this->MPIRequests[1][5] = MPI_Recv_init(bBuffs[0]->radiuses,      n, MPIType,  MPIPrevRank, 5);
+	MPI_Recv_init(bBuffs[1]->radiuses,      n, MPIType,  MPIPrevRank, 4), MPI_COMM_WORLD, &this->MPIRequests[0][5];
+	MPI_Recv_init(bBuffs[0]->radiuses,      n, MPIType,  MPIPrevRank, 5), MPI_COMM_WORLD, &this->MPIRequests[1][5];
 
 	// send positions.x
-	this->MPIRequests[0][6] = MPI_Send_init(bBuffs[0]->positions.x,   n, MPIType,  MPINextRank, 6);
-	this->MPIRequests[1][6] = MPI_Send_init(bBuffs[1]->positions.x,   n, MPIType,  MPINextRank, 7);
+	MPI_Send_init(bBuffs[0]->positions.x,   n, MPIType,  MPINextRank, 6, MPI_COMM_WORLD, &this->MPIRequests[0][6]);
+	MPI_Send_init(bBuffs[1]->positions.x,   n, MPIType,  MPINextRank, 7, MPI_COMM_WORLD, &this->MPIRequests[1][6]);
 	// receive positions.x
-	this->MPIRequests[0][7] = MPI_Recv_init(bBuffs[1]->positions.x,   n, MPIType,  MPIPrevRank, 6);
-	this->MPIRequests[1][7] = MPI_Recv_init(bBuffs[0]->positions.x,   n, MPIType,  MPIPrevRank, 7);
+	MPI_Recv_init(bBuffs[1]->positions.x,   n, MPIType,  MPIPrevRank, 6, MPI_COMM_WORLD, &this->MPIRequests[0][7]);
+	MPI_Recv_init(bBuffs[0]->positions.x,   n, MPIType,  MPIPrevRank, 7, MPI_COMM_WORLD, &this->MPIRequests[1][7]);
 
 	// send positions.y
-	this->MPIRequests[0][8] = MPI_Send_init(bBuffs[0]->positions.y,   n, MPIType,  MPINextRank, 8);
-	this->MPIRequests[1][8] = MPI_Send_init(bBuffs[1]->positions.y,   n, MPIType,  MPINextRank, 9);
+	MPI_Send_init(bBuffs[0]->positions.y,   n, MPIType,  MPINextRank, 8, MPI_COMM_WORLD, &this->MPIRequests[0][8]);
+	MPI_Send_init(bBuffs[1]->positions.y,   n, MPIType,  MPINextRank, 9, MPI_COMM_WORLD, &this->MPIRequests[1][8]);
 	// receive positions.y
-	this->MPIRequests[0][9] = MPI_Recv_init(bBuffs[1]->positions.y,   n, MPIType,  MPIPrevRank, 8);
-	this->MPIRequests[1][9] = MPI_Recv_init(bBuffs[0]->positions.y,   n, MPIType,  MPIPrevRank, 9);
+	MPI_Recv_init(bBuffs[1]->positions.y,   n, MPIType,  MPIPrevRank, 8, MPI_COMM_WORLD, &this->MPIRequests[0][9]);
+	MPI_Recv_init(bBuffs[0]->positions.y,   n, MPIType,  MPIPrevRank, 9, MPI_COMM_WORLD, &this->MPIRequests[1][9]);
 
 	// send positions.z
-	this->MPIRequests[0][10] = MPI_Send_init(bBuffs[0]->positions.z,  n, MPIType, MPINextRank, 10);
-	this->MPIRequests[1][10] = MPI_Send_init(bBuffs[1]->positions.z,  n, MPIType, MPINextRank, 11);
+	MPI_Send_init(bBuffs[0]->positions.z,  n, MPIType, MPINextRank, 10, MPI_COMM_WORLD, &this->MPIRequests[0][10]);
+	MPI_Send_init(bBuffs[1]->positions.z,  n, MPIType, MPINextRank, 11, MPI_COMM_WORLD, &this->MPIRequests[1][10]);
 	// receive positions.z
-	this->MPIRequests[0][11] = MPI_Recv_init(bBuffs[1]->positions.z,  n, MPIType, MPIPrevRank, 10);
-	this->MPIRequests[1][11] = MPI_Recv_init(bBuffs[0]->positions.z,  n, MPIType, MPIPrevRank, 11);
+	MPI_Recv_init(bBuffs[1]->positions.z,  n, MPIType, MPIPrevRank, 10, MPI_COMM_WORLD, &this->MPIRequests[0][11]);
+	MPI_Recv_init(bBuffs[0]->positions.z,  n, MPIType, MPIPrevRank, 11, MPI_COMM_WORLD, &this->MPIRequests[1][11]);
 
 	// send velocities.x
-	this->MPIRequests[0][12] = MPI_Send_init(bBuffs[0]->velocities.x, n, MPIType, MPINextRank, 12);
-	this->MPIRequests[1][12] = MPI_Send_init(bBuffs[1]->velocities.x, n, MPIType, MPINextRank, 13);
+	MPI_Send_init(bBuffs[0]->velocities.x, n, MPIType, MPINextRank, 12, MPI_COMM_WORLD, &this->MPIRequests[0][12]);
+	MPI_Send_init(bBuffs[1]->velocities.x, n, MPIType, MPINextRank, 13, MPI_COMM_WORLD, &this->MPIRequests[1][12]);
 	// receive velocities.x
-	this->MPIRequests[0][13] = MPI_Recv_init(bBuffs[1]->velocities.x, n, MPIType, MPIPrevRank, 12);
-	this->MPIRequests[1][13] = MPI_Recv_init(bBuffs[0]->velocities.x, n, MPIType, MPIPrevRank, 13);
+	MPI_Recv_init(bBuffs[1]->velocities.x, n, MPIType, MPIPrevRank, 12, MPI_COMM_WORLD, &this->MPIRequests[0][13]);
+	MPI_Recv_init(bBuffs[0]->velocities.x, n, MPIType, MPIPrevRank, 13, MPI_COMM_WORLD, &this->MPIRequests[1][13]);
 
 	// send velocities.y
-	this->MPIRequests[0][14] = MPI_Send_init(bBuffs[0]->velocities.y, n, MPIType, MPINextRank, 14);
-	this->MPIRequests[1][14] = MPI_Send_init(bBuffs[1]->velocities.y, n, MPIType, MPINextRank, 15);
+	MPI_Send_init(bBuffs[0]->velocities.y, n, MPIType, MPINextRank, 14, MPI_COMM_WORLD, &this->MPIRequests[0][14]);
+	MPI_Send_init(bBuffs[1]->velocities.y, n, MPIType, MPINextRank, 15, MPI_COMM_WORLD, &this->MPIRequests[1][14]);
 	// receive velocities.y
-	this->MPIRequests[0][15] = MPI_Recv_init(bBuffs[1]->velocities.y, n, MPIType, MPIPrevRank, 14);
-	this->MPIRequests[1][15] = MPI_Recv_init(bBuffs[0]->velocities.y, n, MPIType, MPIPrevRank, 15);
+	MPI_Recv_init(bBuffs[1]->velocities.y, n, MPIType, MPIPrevRank, 14, MPI_COMM_WORLD, &this->MPIRequests[0][15]);
+	MPI_Recv_init(bBuffs[0]->velocities.y, n, MPIType, MPIPrevRank, 15, MPI_COMM_WORLD, &this->MPIRequests[1][15]);
 
 	// send velocities.z
-	this->MPIRequests[0][16] = MPI_Send_init(bBuffs[0]->velocities.z, n, MPIType, MPINextRank, 16);
-	this->MPIRequests[1][16] = MPI_Send_init(bBuffs[1]->velocities.z, n, MPIType, MPINextRank, 17);
+	MPI_Send_init(bBuffs[0]->velocities.z, n, MPIType, MPINextRank, 16, MPI_COMM_WORLD, &this->MPIRequests[0][16]);
+	MPI_Send_init(bBuffs[1]->velocities.z, n, MPIType, MPINextRank, 17, MPI_COMM_WORLD, &this->MPIRequests[1][16]);
 	// receive velocities.z
-	this->MPIRequests[0][17] = MPI_Recv_init(bBuffs[1]->velocities.z, n, MPIType, MPIPrevRank, 16);
-	this->MPIRequests[1][17] = MPI_Recv_init(bBuffs[0]->velocities.z, n, MPIType, MPIPrevRank, 17);
+	MPI_Recv_init(bBuffs[1]->velocities.z, n, MPIType, MPIPrevRank, 16, MPI_COMM_WORLD, &this->MPIRequests[0][17]);
+	MPI_Recv_init(bBuffs[0]->velocities.z, n, MPIType, MPIPrevRank, 17, MPI_COMM_WORLD, &this->MPIRequests[1][17]);
 }
 
 template <typename T>

--- a/src/murb/core/collisionless/SimulationNBodyMPI.cpp
+++ b/src/murb/core/collisionless/SimulationNBodyMPI.cpp
@@ -33,10 +33,10 @@ inline int  omp_get_thread_num (   ) { return 0; }
 
 template <typename T>
 SimulationNBodyMPI<T>::SimulationNBodyMPI(const unsigned long nBodies)
-	: SimulationNBody<T>(new Bodies<T>(nBodies, MPI::COMM_WORLD.Get_rank() * nBodies +1)),
+	: SimulationNBody<T>(new Bodies<T>(nBodies, MPI_COMM_WORLD.Get_rank() * nBodies +1)),
 	  neighborBodies    (NULL),
-	  MPISize           (MPI::COMM_WORLD.Get_size()),
-	  MPIRank           (MPI::COMM_WORLD.Get_rank()),
+	  MPISize           (MPI_COMM_WORLD.Get_size()),
+	  MPIRank           (MPI_COMM_WORLD.Get_rank()),
 	  MPIBodiesBuffers  {this->bodies->getN(), this->bodies->getN()}
 {
 	this->init();
@@ -46,8 +46,8 @@ template <typename T>
 SimulationNBodyMPI<T>::SimulationNBodyMPI(const std::string inputFileName)
 	: SimulationNBody<T>(new Bodies<T>(inputFileName)),
 	  neighborBodies    (NULL),
-	  MPISize           (MPI::COMM_WORLD.Get_size()),
-	  MPIRank           (MPI::COMM_WORLD.Get_rank()),
+	  MPISize           (MPI_COMM_WORLD.Get_size()),
+	  MPIRank           (MPI_COMM_WORLD.Get_rank()),
 	  MPIBodiesBuffers  {this->bodies->getN(), this->bodies->getN()}
 {
 	this->init();
@@ -57,7 +57,7 @@ template <typename T>
 void SimulationNBodyMPI<T>::init()
 {
 	const unsigned long n = this->bodies->getN() + this->bodies->getPadding();
-	MPI::Datatype MPIType = ToMPIDatatype<T>::value();
+	MPI_Datatype MPIType = ToMPIDatatype<T>::value();
 
 	// who is next or previous MPI process ?
 	int MPIPrevRank = (this->MPIRank == 0) ? this->MPISize -1 : this->MPIRank -1;
@@ -66,67 +66,67 @@ void SimulationNBodyMPI<T>::init()
 	Bodies<T> *bBuffs[] = {&this->MPIBodiesBuffers[0], &this->MPIBodiesBuffers[1]};
 
 	// send number of bodies
-	this->MPIRequests[0][0] = MPI::COMM_WORLD.Send_init(&bBuffs[0]->n,            1, MPI_LONG, MPINextRank, 0);
-	this->MPIRequests[1][0] = MPI::COMM_WORLD.Send_init(&bBuffs[1]->n,            1, MPI_LONG, MPINextRank, 1);
+	this->MPIRequests[0][0] = MPI_Send_init(&bBuffs[0]->n,            1, MPI_LONG, MPINextRank, 0);
+	this->MPIRequests[1][0] = MPI_Send_init(&bBuffs[1]->n,            1, MPI_LONG, MPINextRank, 1);
 	// receive number of bodies
-	this->MPIRequests[0][1] = MPI::COMM_WORLD.Recv_init(&bBuffs[1]->n,            1, MPI_LONG, MPIPrevRank, 0);
-	this->MPIRequests[1][1] = MPI::COMM_WORLD.Recv_init(&bBuffs[0]->n,            1, MPI_LONG, MPIPrevRank, 1);
+	this->MPIRequests[0][1] = MPI_Recv_init(&bBuffs[1]->n,            1, MPI_LONG, MPIPrevRank, 0);
+	this->MPIRequests[1][1] = MPI_Recv_init(&bBuffs[0]->n,            1, MPI_LONG, MPIPrevRank, 1);
 
 	// send masses
-	this->MPIRequests[0][2] = MPI::COMM_WORLD.Send_init(bBuffs[0]->masses,        n, MPIType,  MPINextRank, 2);
-	this->MPIRequests[1][2] = MPI::COMM_WORLD.Send_init(bBuffs[1]->masses,        n, MPIType,  MPINextRank, 3);
+	this->MPIRequests[0][2] = MPI_Send_init(bBuffs[0]->masses,        n, MPIType,  MPINextRank, 2);
+	this->MPIRequests[1][2] = MPI_Send_init(bBuffs[1]->masses,        n, MPIType,  MPINextRank, 3);
 	// receive masses
-	this->MPIRequests[0][3] = MPI::COMM_WORLD.Recv_init(bBuffs[1]->masses,        n, MPIType,  MPIPrevRank, 2);
-	this->MPIRequests[1][3] = MPI::COMM_WORLD.Recv_init(bBuffs[0]->masses,        n, MPIType,  MPIPrevRank, 3);
+	this->MPIRequests[0][3] = MPI_Recv_init(bBuffs[1]->masses,        n, MPIType,  MPIPrevRank, 2);
+	this->MPIRequests[1][3] = MPI_Recv_init(bBuffs[0]->masses,        n, MPIType,  MPIPrevRank, 3);
 
 	// send radiuses
-	this->MPIRequests[0][4] = MPI::COMM_WORLD.Send_init(bBuffs[0]->radiuses,      n, MPIType,  MPINextRank, 4);
-	this->MPIRequests[1][4] = MPI::COMM_WORLD.Send_init(bBuffs[1]->radiuses,      n, MPIType,  MPINextRank, 5);
+	this->MPIRequests[0][4] = MPI_Send_init(bBuffs[0]->radiuses,      n, MPIType,  MPINextRank, 4);
+	this->MPIRequests[1][4] = MPI_Send_init(bBuffs[1]->radiuses,      n, MPIType,  MPINextRank, 5);
 	// receive radiuses
-	this->MPIRequests[0][5] = MPI::COMM_WORLD.Recv_init(bBuffs[1]->radiuses,      n, MPIType,  MPIPrevRank, 4);
-	this->MPIRequests[1][5] = MPI::COMM_WORLD.Recv_init(bBuffs[0]->radiuses,      n, MPIType,  MPIPrevRank, 5);
+	this->MPIRequests[0][5] = MPI_Recv_init(bBuffs[1]->radiuses,      n, MPIType,  MPIPrevRank, 4);
+	this->MPIRequests[1][5] = MPI_Recv_init(bBuffs[0]->radiuses,      n, MPIType,  MPIPrevRank, 5);
 
 	// send positions.x
-	this->MPIRequests[0][6] = MPI::COMM_WORLD.Send_init(bBuffs[0]->positions.x,   n, MPIType,  MPINextRank, 6);
-	this->MPIRequests[1][6] = MPI::COMM_WORLD.Send_init(bBuffs[1]->positions.x,   n, MPIType,  MPINextRank, 7);
+	this->MPIRequests[0][6] = MPI_Send_init(bBuffs[0]->positions.x,   n, MPIType,  MPINextRank, 6);
+	this->MPIRequests[1][6] = MPI_Send_init(bBuffs[1]->positions.x,   n, MPIType,  MPINextRank, 7);
 	// receive positions.x
-	this->MPIRequests[0][7] = MPI::COMM_WORLD.Recv_init(bBuffs[1]->positions.x,   n, MPIType,  MPIPrevRank, 6);
-	this->MPIRequests[1][7] = MPI::COMM_WORLD.Recv_init(bBuffs[0]->positions.x,   n, MPIType,  MPIPrevRank, 7);
+	this->MPIRequests[0][7] = MPI_Recv_init(bBuffs[1]->positions.x,   n, MPIType,  MPIPrevRank, 6);
+	this->MPIRequests[1][7] = MPI_Recv_init(bBuffs[0]->positions.x,   n, MPIType,  MPIPrevRank, 7);
 
 	// send positions.y
-	this->MPIRequests[0][8] = MPI::COMM_WORLD.Send_init(bBuffs[0]->positions.y,   n, MPIType,  MPINextRank, 8);
-	this->MPIRequests[1][8] = MPI::COMM_WORLD.Send_init(bBuffs[1]->positions.y,   n, MPIType,  MPINextRank, 9);
+	this->MPIRequests[0][8] = MPI_Send_init(bBuffs[0]->positions.y,   n, MPIType,  MPINextRank, 8);
+	this->MPIRequests[1][8] = MPI_Send_init(bBuffs[1]->positions.y,   n, MPIType,  MPINextRank, 9);
 	// receive positions.y
-	this->MPIRequests[0][9] = MPI::COMM_WORLD.Recv_init(bBuffs[1]->positions.y,   n, MPIType,  MPIPrevRank, 8);
-	this->MPIRequests[1][9] = MPI::COMM_WORLD.Recv_init(bBuffs[0]->positions.y,   n, MPIType,  MPIPrevRank, 9);
+	this->MPIRequests[0][9] = MPI_Recv_init(bBuffs[1]->positions.y,   n, MPIType,  MPIPrevRank, 8);
+	this->MPIRequests[1][9] = MPI_Recv_init(bBuffs[0]->positions.y,   n, MPIType,  MPIPrevRank, 9);
 
 	// send positions.z
-	this->MPIRequests[0][10] = MPI::COMM_WORLD.Send_init(bBuffs[0]->positions.z,  n, MPIType, MPINextRank, 10);
-	this->MPIRequests[1][10] = MPI::COMM_WORLD.Send_init(bBuffs[1]->positions.z,  n, MPIType, MPINextRank, 11);
+	this->MPIRequests[0][10] = MPI_Send_init(bBuffs[0]->positions.z,  n, MPIType, MPINextRank, 10);
+	this->MPIRequests[1][10] = MPI_Send_init(bBuffs[1]->positions.z,  n, MPIType, MPINextRank, 11);
 	// receive positions.z
-	this->MPIRequests[0][11] = MPI::COMM_WORLD.Recv_init(bBuffs[1]->positions.z,  n, MPIType, MPIPrevRank, 10);
-	this->MPIRequests[1][11] = MPI::COMM_WORLD.Recv_init(bBuffs[0]->positions.z,  n, MPIType, MPIPrevRank, 11);
+	this->MPIRequests[0][11] = MPI_Recv_init(bBuffs[1]->positions.z,  n, MPIType, MPIPrevRank, 10);
+	this->MPIRequests[1][11] = MPI_Recv_init(bBuffs[0]->positions.z,  n, MPIType, MPIPrevRank, 11);
 
 	// send velocities.x
-	this->MPIRequests[0][12] = MPI::COMM_WORLD.Send_init(bBuffs[0]->velocities.x, n, MPIType, MPINextRank, 12);
-	this->MPIRequests[1][12] = MPI::COMM_WORLD.Send_init(bBuffs[1]->velocities.x, n, MPIType, MPINextRank, 13);
+	this->MPIRequests[0][12] = MPI_Send_init(bBuffs[0]->velocities.x, n, MPIType, MPINextRank, 12);
+	this->MPIRequests[1][12] = MPI_Send_init(bBuffs[1]->velocities.x, n, MPIType, MPINextRank, 13);
 	// receive velocities.x
-	this->MPIRequests[0][13] = MPI::COMM_WORLD.Recv_init(bBuffs[1]->velocities.x, n, MPIType, MPIPrevRank, 12);
-	this->MPIRequests[1][13] = MPI::COMM_WORLD.Recv_init(bBuffs[0]->velocities.x, n, MPIType, MPIPrevRank, 13);
+	this->MPIRequests[0][13] = MPI_Recv_init(bBuffs[1]->velocities.x, n, MPIType, MPIPrevRank, 12);
+	this->MPIRequests[1][13] = MPI_Recv_init(bBuffs[0]->velocities.x, n, MPIType, MPIPrevRank, 13);
 
 	// send velocities.y
-	this->MPIRequests[0][14] = MPI::COMM_WORLD.Send_init(bBuffs[0]->velocities.y, n, MPIType, MPINextRank, 14);
-	this->MPIRequests[1][14] = MPI::COMM_WORLD.Send_init(bBuffs[1]->velocities.y, n, MPIType, MPINextRank, 15);
+	this->MPIRequests[0][14] = MPI_Send_init(bBuffs[0]->velocities.y, n, MPIType, MPINextRank, 14);
+	this->MPIRequests[1][14] = MPI_Send_init(bBuffs[1]->velocities.y, n, MPIType, MPINextRank, 15);
 	// receive velocities.y
-	this->MPIRequests[0][15] = MPI::COMM_WORLD.Recv_init(bBuffs[1]->velocities.y, n, MPIType, MPIPrevRank, 14);
-	this->MPIRequests[1][15] = MPI::COMM_WORLD.Recv_init(bBuffs[0]->velocities.y, n, MPIType, MPIPrevRank, 15);
+	this->MPIRequests[0][15] = MPI_Recv_init(bBuffs[1]->velocities.y, n, MPIType, MPIPrevRank, 14);
+	this->MPIRequests[1][15] = MPI_Recv_init(bBuffs[0]->velocities.y, n, MPIType, MPIPrevRank, 15);
 
 	// send velocities.z
-	this->MPIRequests[0][16] = MPI::COMM_WORLD.Send_init(bBuffs[0]->velocities.z, n, MPIType, MPINextRank, 16);
-	this->MPIRequests[1][16] = MPI::COMM_WORLD.Send_init(bBuffs[1]->velocities.z, n, MPIType, MPINextRank, 17);
+	this->MPIRequests[0][16] = MPI_Send_init(bBuffs[0]->velocities.z, n, MPIType, MPINextRank, 16);
+	this->MPIRequests[1][16] = MPI_Send_init(bBuffs[1]->velocities.z, n, MPIType, MPINextRank, 17);
 	// receive velocities.z
-	this->MPIRequests[0][17] = MPI::COMM_WORLD.Recv_init(bBuffs[1]->velocities.z, n, MPIType, MPIPrevRank, 16);
-	this->MPIRequests[1][17] = MPI::COMM_WORLD.Recv_init(bBuffs[0]->velocities.z, n, MPIType, MPIPrevRank, 17);
+	this->MPIRequests[0][17] = MPI_Recv_init(bBuffs[1]->velocities.z, n, MPIType, MPIPrevRank, 16);
+	this->MPIRequests[1][17] = MPI_Recv_init(bBuffs[0]->velocities.z, n, MPIType, MPIPrevRank, 17);
 }
 
 template <typename T>
@@ -143,20 +143,20 @@ void SimulationNBodyMPI<T>::computeOneIteration()
 	this->initIteration();
 
 	// compute bodies acceleration ------------------------------------------------------------------------------------
-	MPI::Prequest::Startall(2*9, this->MPIRequests[0]);
+	MPI_Prequest::Startall(2*9, this->MPIRequests[0]);
 
 	this->computeLocalBodiesAcceleration();
  
 	for(int iStep = 1; iStep < this->MPISize; ++iStep)
 	{
-		MPI::Request::Waitall(2*9, this->MPIRequests[(iStep -1) % 2]);
+		MPI_Request::Waitall(2*9, this->MPIRequests[(iStep -1) % 2]);
 
 		this->neighborBodies = &this->MPIBodiesBuffers[iStep % 2];
 
 		this->computeNeighborBodiesAcceleration();
 
 		if(iStep < this->MPISize -1)
-			MPI::Prequest::Startall(2*9, this->MPIRequests[iStep % 2]);
+			MPI_Prequest::Startall(2*9, this->MPIRequests[iStep % 2]);
 	}
 	// ----------------------------------------------------------------------------------------------------------------
 
@@ -182,7 +182,7 @@ void SimulationNBodyMPI<T>::findTimeStep()
 		for(unsigned long iBody = 0; iBody < this->bodies->getN(); iBody++)
 			localDt = std::min(localDt, this->computeTimeStep(iBody));
 
-		MPI::COMM_WORLD.Allreduce(&localDt, &this->dt, 1, ToMPIDatatype<T>::value(), MPI_MIN);
+		MPI_COMM_WORLD.Allreduce(&localDt, &this->dt, 1, ToMPIDatatype<T>::value(), MPI_MIN);
 
 		if(this->dt < this->minDt)
 			this->dt = this->minDt;

--- a/src/murb/core/collisionless/SimulationNBodyMPI.h
+++ b/src/murb/core/collisionless/SimulationNBodyMPI.h
@@ -34,7 +34,7 @@ protected:
 
 private:
 	Bodies<T>     MPIBodiesBuffers[2];
-	MPI::Prequest MPIRequests[2][2*9];
+	MPI_Prequest MPIRequests[2][2*9];
 
 protected:
 	SimulationNBodyMPI(const unsigned long nBodies);

--- a/src/murb/core/collisionless/SimulationNBodyMPI.h
+++ b/src/murb/core/collisionless/SimulationNBodyMPI.h
@@ -34,7 +34,7 @@ protected:
 
 private:
 	Bodies<T>     MPIBodiesBuffers[2];
-	MPI_Prequest MPIRequests[2][2*9];
+	MPI_Request   MPIRequests[2][2*9];
 
 protected:
 	SimulationNBodyMPI(const unsigned long nBodies);

--- a/src/murb/main.cpp
+++ b/src/murb/main.cpp
@@ -68,7 +68,7 @@ inline int  omp_get_thread_num (   ) { return 0; }
 #include <mpi.h>
 #include "core/collisionless/v1/mpi/SimulationNBodyMPIV1.h"
 #include "core/collisionless/v1/mpi/SimulationNBodyMPIV1Intrinsics.h"
-#include "../common/utils/ToMPIDataType.h"
+#include "../common/utils/ToMPIDatatype.h"
 #else
 #ifndef NO_MPI
 #define NO_MPI
@@ -466,7 +466,7 @@ void writeBodies(SimulationNBody<T> *simu, const unsigned long &iIte)
 
 		for(unsigned long iRank = 0; iRank < (unsigned long)MPI_get_size(); iRank++)
 		{
-			if(iRank == (unsigned longgI_COMM_WORLD.Get_rank())
+			if(iRank == (unsigned long)MPI_get_rank())
 				if(!simu->getBodies()->writeIntoFileMPIBinary(outputFileName, MPINBodies))
 					MPI_Abort(MPI_COMM_WORLD, 1);
 
@@ -498,7 +498,7 @@ void writeBodies(SimulationNBody<T> *simu, const unsigned long &iIte)
  */
 int main(int argc, char** argv)
 {
-	MPI_Init();
+	MPI_Init(&argc, &argv);
 
 	// read arguments from the command line
 	// usage: ./nbody -f fileName -i nIterations [-v] [-w] ...

--- a/src/murb/main.cpp
+++ b/src/murb/main.cpp
@@ -68,26 +68,14 @@ inline int  omp_get_thread_num (   ) { return 0; }
 #include <mpi.h>
 #include "core/collisionless/v1/mpi/SimulationNBodyMPIV1.h"
 #include "core/collisionless/v1/mpi/SimulationNBodyMPIV1Intrinsics.h"
+#include "../common/utils/ToMPIDataType.h"
 #else
 #ifndef NO_MPI
 #define NO_MPI
-namespace MPI
-{
-	inline void Init()     {}
-	inline void Finalize() {}
-
-	class Comm {
-	public:
-		                   Comm     (       ) {            };
-		virtual            ~Comm    (       ) {            };
-		static inline int  Get_rank (       ) { return 0;  };
-		static inline int  Get_size (       ) { return 1;  };
-		static inline void Barrier  (       ) {            };
-		static inline void Abort    (int val) { exit(val); };
-	};
-
-	Comm COMM_WORLD;
-}
+static inline int  MPI_get_rank (       ) { return 0;  };
+static inline int  MPI_get_size (       ) { return 1;  };
+static inline int  MPI_Barrier  (MPI_Comm comm)         {            };
+static inline int  MPI_Abort    (MPI_Comm comm int val) { exit(val); };
 #endif
 #endif
 
@@ -159,7 +147,7 @@ void argsReader(int argc, char** argv)
 
 	if(argsReader.parse_arguments(reqArgs1, faculArgs))
 	{
-		NBodies           = stoi(argsReader.get_argument("n")) / MPI_COMM_WORLD.Get_size();
+		NBodies           = stoi(argsReader.get_argument("n")) / MPI_get_size();
 		NIterations       = stoi(argsReader.get_argument("i"));
 		RootInputFileName = "";
 	}
@@ -265,12 +253,12 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 {
 	SimulationNBody<floatType> *simu = nullptr;
 
-	string inputFileName = RootInputFileName + ".p" + to_string(MPI_COMM_WORLD.Get_rank()) + ".dat";
+	string inputFileName = RootInputFileName + ".p" + to_string(MPI_get_rank()) + ".dat";
 
 	switch(ImplId)
 	{
 		case 10:
-			if(!MPI_COMM_WORLD.Get_rank())
+			if(!MPI_get_rank())
 				cout << "Selected implementation: V1 - O(n²)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyV1<T>(NBodies);
@@ -278,7 +266,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyV1<T>(inputFileName);
 			break;
 		case 11:
-			if(!MPI_COMM_WORLD.Get_rank())
+			if(!MPI_get_rank())
 				cout << "Selected implementation: V1 + cache blocking - O(n²)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyV1CB<T>(NBodies);
@@ -286,7 +274,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyV1CB<T>(inputFileName);
 			break;
 		case 12:
-			if(!MPI_COMM_WORLD.Get_rank())
+			if(!MPI_get_rank())
 				cout << "Selected implementation: V1 + vectors - O(n²)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyV1Vectors<T>(NBodies);
@@ -294,7 +282,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyV1Vectors<T>(inputFileName);
 			break;
 		case 13:
-			if(!MPI_COMM_WORLD.Get_rank())
+			if(!MPI_get_rank())
 				cout << "Selected implementation: V1 + intrinsics - O(n²)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyV1Intrinsics<T>(NBodies);
@@ -302,7 +290,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyV1Intrinsics<T>(inputFileName);
 			break;
 		case 14:
-			if(!MPI_COMM_WORLD.Get_rank())
+			if(!MPI_get_rank())
 				cout << "Selected implementation: V1 + collisions - O(n²)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyCollisionV1<T>(NBodies);
@@ -310,7 +298,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyCollisionV1<T>(inputFileName);
 			break;
 		case 20:
-			if(!MPI_COMM_WORLD.Get_rank())
+			if(!MPI_get_rank())
 				cout << "Selected implementation: V2 - O(n²/2)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyV2<T>(NBodies);
@@ -318,7 +306,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyV2<T>(inputFileName);
 			break;
 		case 21:
-			if(!MPI_COMM_WORLD.Get_rank())
+			if(!MPI_get_rank())
 				cout << "Selected implementation: V2 + cache blocking - O(n²/2)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyV2CB<T>(NBodies);
@@ -326,7 +314,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyV2CB<T>(inputFileName);
 			break;
 		case 22:
-			if(!MPI_COMM_WORLD.Get_rank())
+			if(!MPI_get_rank())
 				cout << "Selected implementation: V2 + vectors - O(n²/2)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyV2Vectors<T>(NBodies);
@@ -341,7 +329,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyV2Intrinsics<T>(inputFileName);
 			break;
 		case 30:
-			if(!MPI_COMM_WORLD.Get_rank())
+			if(!MPI_get_rank())
 				cout << "Selected implementation: V3 (softening factor) - O(n²)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyV3<T>(NBodies, Softening);
@@ -349,7 +337,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyV3<T>(inputFileName, Softening);
 			break;
 		case 33:
-			if(!MPI_COMM_WORLD.Get_rank())
+			if(!MPI_get_rank())
 				cout << "Selected implementation: V3 (softening factor) + intrinsics - O(n²)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyV3Intrinsics<T>(NBodies, Softening);
@@ -357,7 +345,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyV3Intrinsics<T>(inputFileName, Softening);
 			break;
 		case 34:
-			if(!MPI_COMM_WORLD.Get_rank())
+			if(!MPI_get_rank())
 				cout << "Selected implementation: V3 (softening factor) + intrinsics Black Hole - O(n²)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyV3IntrinsicsBH<T>(NBodies, Softening);
@@ -366,7 +354,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 			break;
 #ifndef NO_MPI
 		case 100:
-			if(!MPI_COMM_WORLD.Get_rank())
+			if(!MPI_get_rank())
 				cout << "Selected implementation: V1 MPI - O(n²)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyMPIV1<T>(NBodies);
@@ -374,7 +362,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyMPIV1<T>(inputFileName);
 			break;
 		case 103:
-			if(!MPI_COMM_WORLD.Get_rank())
+			if(!MPI_get_rank())
 				cout << "Selected implementation: V1 MPI + intrinsics - O(n²)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyMPIV1Intrinsics<T>(NBodies);
@@ -383,16 +371,16 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 			break;
 #endif
 		default:
-			if(!MPI_COMM_WORLD.Get_rank())
+			if(!MPI_get_rank())
 				cout << "This code implementation does not exist... Exiting." << endl;
 			MPI_Finalize();
 			exit(-1);
 			break;
 	}
 
-	if(ImplId < 100 && MPI_COMM_WORLD.Get_size() > 1)
+	if(ImplId < 100 && MPI_get_size() > 1)
 	{
-		if(!MPI_COMM_WORLD.Get_rank())
+		if(!MPI_get_rank())
 			cout << "Implementation n°" << ImplId << " is not an MPI implementation... Exiting." << endl;
 		MPI_Finalize();
 		exit(-1);
@@ -417,7 +405,7 @@ SpheresVisu* selectImplementationAndAllocateVisu(SimulationNBody<T> *simu)
 
 #ifdef VISU
 	// only the MPI proc 0 can display the bodies
-	if(MPI_COMM_WORLD.Get_rank())
+	if(MPI_get_rank())
 		VisuEnable = false;
 
 	if(VisuEnable)
@@ -473,26 +461,26 @@ void writeBodies(SimulationNBody<T> *simu, const unsigned long &iIte)
 		outputFileName = tmpFileName + ".p0.dat";
 
 		unsigned long MPINBodies = 0;
-		if(!MPI_COMM_WORLD.Get_rank())
-			MPINBodies = simu->getBodies()->getN() * MPI_COMM_WORLD.Get_size();
+		if(!MPI_get_rank())
+			MPINBodies = simu->getBodies()->getN() * MPI_get_size();
 
-		for(unsigned long iRank = 0; iRank < (unsigned long)MPI_COMM_WORLD.Get_size(); iRank++)
+		for(unsigned long iRank = 0; iRank < (unsigned long)MPI_get_size(); iRank++)
 		{
-			if(iRank == (unsigned long)MPI_COMM_WORLD.Get_rank())
+			if(iRank == (unsigned longgI_COMM_WORLD.Get_rank())
 				if(!simu->getBodies()->writeIntoFileMPIBinary(outputFileName, MPINBodies))
-					MPI_COMM_WORLD.Abort(-1);
+					MPI_Abort(MPI_COMM_WORLD, 1);
 
-			MPI_COMM_WORLD.Barrier();
+			MPI_Barrier(MPI_COMM_WORLD);
 		}
 	}
 	else // each process MPI writes its bodies in separate files
 	{
 		tmpFileName = RootOutputFileName + ".i" + to_string(iIte);
-		outputFileName = tmpFileName + ".p" + to_string(MPI_COMM_WORLD.Get_rank()) + ".dat";
+		outputFileName = tmpFileName + ".p" + to_string(MPI_get_rank()) + ".dat";
 		simu->getBodies()->writeIntoFileBinary(outputFileName);
 	}
 
-	if(Verbose && !MPI_COMM_WORLD.Get_rank())
+	if(Verbose && !MPI_get_rank())
 	{
 		tmpFileName = tmpFileName + ".p*.dat";
 		cout << "   Writing iteration n°" << iIte << " into \"" << tmpFileName << "\" file(s)." << endl;
@@ -526,7 +514,7 @@ int main(int argc, char** argv)
 	float Mbytes = simu->getAllocatedBytes() / 1024.f / 1024.f;
 
 	// display simulation configuration
-	if(!MPI_COMM_WORLD.Get_rank())
+	if(!MPI_get_rank())
 	{
 		cout << "n-body simulation configuration:" << endl;
 		cout << "--------------------------------" << endl;
@@ -536,7 +524,7 @@ int main(int argc, char** argv)
 			cout << "  -> random mode           : enable" << endl;
 		if(!RootOutputFileName.empty())
 			cout << "  -> output file name(s)   : " << RootOutputFileName << ".i*.p*.dat" << endl;
-		cout << "  -> total nb. of bodies   : " << NBodies * MPI_COMM_WORLD.Get_size() << endl;
+		cout << "  -> total nb. of bodies   : " << NBodies * MPI_get_size() << endl;
 		cout << "  -> nb. of bodies per proc: " << NBodies << endl;
 		cout << "  -> nb. of iterations     : " << NIterations << endl;
 		cout << "  -> verbose mode          : " << ((Verbose) ? "enable" : "disable") << endl;
@@ -546,14 +534,14 @@ int main(int argc, char** argv)
 		cout << "  -> time step             : " << ((DtVariable) ? "variable" : to_string(Dt) + " sec") << endl;
 		if (ImplId >= 30 && ImplId <= 39)
 		cout << "  -> softening factor      : " << Softening << endl;
-		cout << "  -> nb. of MPI procs      : " << MPI_COMM_WORLD.Get_size() << endl;
+		cout << "  -> nb. of MPI procs      : " << MPI_get_size() << endl;
 		cout << "  -> nb. of threads        : " << omp_get_max_threads() << endl << endl;
 	}
 
 	// initialize visualization of bodies (with spheres in space)
 	SpheresVisu *visu = selectImplementationAndAllocateVisu<floatType>(simu);
 
-	if(!MPI_COMM_WORLD.Get_rank())
+	if(!MPI_get_rank())
 		cout << "Simulation started..." << endl;
 
 	// write initial bodies into file
@@ -585,7 +573,7 @@ int main(int argc, char** argv)
 		physicTime += simu->getDt();
 
 		// display the status of this iteration
-		if(Verbose && !MPI_COMM_WORLD.Get_rank())
+		if(Verbose && !MPI_get_rank())
 			cout << "Iteration n°" << setw(4) << iIte << " took "
 			     << setprecision(3) << std::fixed << setw(5) << perfIte.getElapsedTime() << " ms ("
 			     << setprecision(3) << std::fixed << setw(5) << perfIte.getGflops(simu->getFlopsPerIte())
@@ -595,13 +583,13 @@ int main(int argc, char** argv)
 		if(!RootOutputFileName.empty())
 			writeBodies<floatType>(simu, iIte);
 	}
-	if(Verbose && !MPI_COMM_WORLD.Get_rank())
+	if(Verbose && !MPI_get_rank())
 		cout << endl;
 
-	if(!MPI_COMM_WORLD.Get_rank())
+	if(!MPI_get_rank())
 		cout << "Simulation ended." << endl << endl;
 
-	if(!MPI_COMM_WORLD.Get_rank())
+	if(!MPI_get_rank())
 		cout << "Entire simulation took " << perfTotal.getElapsedTime() << " ms "
 		     << "(" << perfTotal.getGflops(simu->getFlopsPerIte() * (iIte -1)) << " Gflop/s)" << endl;
 
@@ -610,7 +598,7 @@ int main(int argc, char** argv)
 	delete simu;
 
 	if(NIterations > (iIte +1))
-		MPI_COMM_WORLD.Abort(0);
+		MPI_Abort(MPI_COMM_WORLD, 0);
 
 	MPI_Finalize();
 

--- a/src/murb/main.cpp
+++ b/src/murb/main.cpp
@@ -159,7 +159,7 @@ void argsReader(int argc, char** argv)
 
 	if(argsReader.parse_arguments(reqArgs1, faculArgs))
 	{
-		NBodies           = stoi(argsReader.get_argument("n")) / MPI::COMM_WORLD.Get_size();
+		NBodies           = stoi(argsReader.get_argument("n")) / MPI_COMM_WORLD.Get_size();
 		NIterations       = stoi(argsReader.get_argument("i"));
 		RootInputFileName = "";
 	}
@@ -265,12 +265,12 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 {
 	SimulationNBody<floatType> *simu = nullptr;
 
-	string inputFileName = RootInputFileName + ".p" + to_string(MPI::COMM_WORLD.Get_rank()) + ".dat";
+	string inputFileName = RootInputFileName + ".p" + to_string(MPI_COMM_WORLD.Get_rank()) + ".dat";
 
 	switch(ImplId)
 	{
 		case 10:
-			if(!MPI::COMM_WORLD.Get_rank())
+			if(!MPI_COMM_WORLD.Get_rank())
 				cout << "Selected implementation: V1 - O(n²)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyV1<T>(NBodies);
@@ -278,7 +278,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyV1<T>(inputFileName);
 			break;
 		case 11:
-			if(!MPI::COMM_WORLD.Get_rank())
+			if(!MPI_COMM_WORLD.Get_rank())
 				cout << "Selected implementation: V1 + cache blocking - O(n²)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyV1CB<T>(NBodies);
@@ -286,7 +286,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyV1CB<T>(inputFileName);
 			break;
 		case 12:
-			if(!MPI::COMM_WORLD.Get_rank())
+			if(!MPI_COMM_WORLD.Get_rank())
 				cout << "Selected implementation: V1 + vectors - O(n²)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyV1Vectors<T>(NBodies);
@@ -294,7 +294,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyV1Vectors<T>(inputFileName);
 			break;
 		case 13:
-			if(!MPI::COMM_WORLD.Get_rank())
+			if(!MPI_COMM_WORLD.Get_rank())
 				cout << "Selected implementation: V1 + intrinsics - O(n²)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyV1Intrinsics<T>(NBodies);
@@ -302,7 +302,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyV1Intrinsics<T>(inputFileName);
 			break;
 		case 14:
-			if(!MPI::COMM_WORLD.Get_rank())
+			if(!MPI_COMM_WORLD.Get_rank())
 				cout << "Selected implementation: V1 + collisions - O(n²)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyCollisionV1<T>(NBodies);
@@ -310,7 +310,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyCollisionV1<T>(inputFileName);
 			break;
 		case 20:
-			if(!MPI::COMM_WORLD.Get_rank())
+			if(!MPI_COMM_WORLD.Get_rank())
 				cout << "Selected implementation: V2 - O(n²/2)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyV2<T>(NBodies);
@@ -318,7 +318,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyV2<T>(inputFileName);
 			break;
 		case 21:
-			if(!MPI::COMM_WORLD.Get_rank())
+			if(!MPI_COMM_WORLD.Get_rank())
 				cout << "Selected implementation: V2 + cache blocking - O(n²/2)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyV2CB<T>(NBodies);
@@ -326,7 +326,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyV2CB<T>(inputFileName);
 			break;
 		case 22:
-			if(!MPI::COMM_WORLD.Get_rank())
+			if(!MPI_COMM_WORLD.Get_rank())
 				cout << "Selected implementation: V2 + vectors - O(n²/2)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyV2Vectors<T>(NBodies);
@@ -341,7 +341,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyV2Intrinsics<T>(inputFileName);
 			break;
 		case 30:
-			if(!MPI::COMM_WORLD.Get_rank())
+			if(!MPI_COMM_WORLD.Get_rank())
 				cout << "Selected implementation: V3 (softening factor) - O(n²)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyV3<T>(NBodies, Softening);
@@ -349,7 +349,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyV3<T>(inputFileName, Softening);
 			break;
 		case 33:
-			if(!MPI::COMM_WORLD.Get_rank())
+			if(!MPI_COMM_WORLD.Get_rank())
 				cout << "Selected implementation: V3 (softening factor) + intrinsics - O(n²)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyV3Intrinsics<T>(NBodies, Softening);
@@ -357,7 +357,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyV3Intrinsics<T>(inputFileName, Softening);
 			break;
 		case 34:
-			if(!MPI::COMM_WORLD.Get_rank())
+			if(!MPI_COMM_WORLD.Get_rank())
 				cout << "Selected implementation: V3 (softening factor) + intrinsics Black Hole - O(n²)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyV3IntrinsicsBH<T>(NBodies, Softening);
@@ -366,7 +366,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 			break;
 #ifndef NO_MPI
 		case 100:
-			if(!MPI::COMM_WORLD.Get_rank())
+			if(!MPI_COMM_WORLD.Get_rank())
 				cout << "Selected implementation: V1 MPI - O(n²)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyMPIV1<T>(NBodies);
@@ -374,7 +374,7 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 				simu = new SimulationNBodyMPIV1<T>(inputFileName);
 			break;
 		case 103:
-			if(!MPI::COMM_WORLD.Get_rank())
+			if(!MPI_COMM_WORLD.Get_rank())
 				cout << "Selected implementation: V1 MPI + intrinsics - O(n²)" << endl << endl;
 			if(RootInputFileName.empty())
 				simu = new SimulationNBodyMPIV1Intrinsics<T>(NBodies);
@@ -383,18 +383,18 @@ SimulationNBody<T>* selectImplementationAndAllocateSimulation()
 			break;
 #endif
 		default:
-			if(!MPI::COMM_WORLD.Get_rank())
+			if(!MPI_COMM_WORLD.Get_rank())
 				cout << "This code implementation does not exist... Exiting." << endl;
-			MPI::Finalize();
+			MPI_Finalize();
 			exit(-1);
 			break;
 	}
 
-	if(ImplId < 100 && MPI::COMM_WORLD.Get_size() > 1)
+	if(ImplId < 100 && MPI_COMM_WORLD.Get_size() > 1)
 	{
-		if(!MPI::COMM_WORLD.Get_rank())
+		if(!MPI_COMM_WORLD.Get_rank())
 			cout << "Implementation n°" << ImplId << " is not an MPI implementation... Exiting." << endl;
-		MPI::Finalize();
+		MPI_Finalize();
 		exit(-1);
 	}
 
@@ -417,7 +417,7 @@ SpheresVisu* selectImplementationAndAllocateVisu(SimulationNBody<T> *simu)
 
 #ifdef VISU
 	// only the MPI proc 0 can display the bodies
-	if(MPI::COMM_WORLD.Get_rank())
+	if(MPI_COMM_WORLD.Get_rank())
 		VisuEnable = false;
 
 	if(VisuEnable)
@@ -473,26 +473,26 @@ void writeBodies(SimulationNBody<T> *simu, const unsigned long &iIte)
 		outputFileName = tmpFileName + ".p0.dat";
 
 		unsigned long MPINBodies = 0;
-		if(!MPI::COMM_WORLD.Get_rank())
-			MPINBodies = simu->getBodies()->getN() * MPI::COMM_WORLD.Get_size();
+		if(!MPI_COMM_WORLD.Get_rank())
+			MPINBodies = simu->getBodies()->getN() * MPI_COMM_WORLD.Get_size();
 
-		for(unsigned long iRank = 0; iRank < (unsigned long)MPI::COMM_WORLD.Get_size(); iRank++)
+		for(unsigned long iRank = 0; iRank < (unsigned long)MPI_COMM_WORLD.Get_size(); iRank++)
 		{
-			if(iRank == (unsigned long)MPI::COMM_WORLD.Get_rank())
+			if(iRank == (unsigned long)MPI_COMM_WORLD.Get_rank())
 				if(!simu->getBodies()->writeIntoFileMPIBinary(outputFileName, MPINBodies))
-					MPI::COMM_WORLD.Abort(-1);
+					MPI_COMM_WORLD.Abort(-1);
 
-			MPI::COMM_WORLD.Barrier();
+			MPI_COMM_WORLD.Barrier();
 		}
 	}
 	else // each process MPI writes its bodies in separate files
 	{
 		tmpFileName = RootOutputFileName + ".i" + to_string(iIte);
-		outputFileName = tmpFileName + ".p" + to_string(MPI::COMM_WORLD.Get_rank()) + ".dat";
+		outputFileName = tmpFileName + ".p" + to_string(MPI_COMM_WORLD.Get_rank()) + ".dat";
 		simu->getBodies()->writeIntoFileBinary(outputFileName);
 	}
 
-	if(Verbose && !MPI::COMM_WORLD.Get_rank())
+	if(Verbose && !MPI_COMM_WORLD.Get_rank())
 	{
 		tmpFileName = tmpFileName + ".p*.dat";
 		cout << "   Writing iteration n°" << iIte << " into \"" << tmpFileName << "\" file(s)." << endl;
@@ -510,7 +510,7 @@ void writeBodies(SimulationNBody<T> *simu, const unsigned long &iIte)
  */
 int main(int argc, char** argv)
 {
-	MPI::Init();
+	MPI_Init();
 
 	// read arguments from the command line
 	// usage: ./nbody -f fileName -i nIterations [-v] [-w] ...
@@ -526,7 +526,7 @@ int main(int argc, char** argv)
 	float Mbytes = simu->getAllocatedBytes() / 1024.f / 1024.f;
 
 	// display simulation configuration
-	if(!MPI::COMM_WORLD.Get_rank())
+	if(!MPI_COMM_WORLD.Get_rank())
 	{
 		cout << "n-body simulation configuration:" << endl;
 		cout << "--------------------------------" << endl;
@@ -536,7 +536,7 @@ int main(int argc, char** argv)
 			cout << "  -> random mode           : enable" << endl;
 		if(!RootOutputFileName.empty())
 			cout << "  -> output file name(s)   : " << RootOutputFileName << ".i*.p*.dat" << endl;
-		cout << "  -> total nb. of bodies   : " << NBodies * MPI::COMM_WORLD.Get_size() << endl;
+		cout << "  -> total nb. of bodies   : " << NBodies * MPI_COMM_WORLD.Get_size() << endl;
 		cout << "  -> nb. of bodies per proc: " << NBodies << endl;
 		cout << "  -> nb. of iterations     : " << NIterations << endl;
 		cout << "  -> verbose mode          : " << ((Verbose) ? "enable" : "disable") << endl;
@@ -546,14 +546,14 @@ int main(int argc, char** argv)
 		cout << "  -> time step             : " << ((DtVariable) ? "variable" : to_string(Dt) + " sec") << endl;
 		if (ImplId >= 30 && ImplId <= 39)
 		cout << "  -> softening factor      : " << Softening << endl;
-		cout << "  -> nb. of MPI procs      : " << MPI::COMM_WORLD.Get_size() << endl;
+		cout << "  -> nb. of MPI procs      : " << MPI_COMM_WORLD.Get_size() << endl;
 		cout << "  -> nb. of threads        : " << omp_get_max_threads() << endl << endl;
 	}
 
 	// initialize visualization of bodies (with spheres in space)
 	SpheresVisu *visu = selectImplementationAndAllocateVisu<floatType>(simu);
 
-	if(!MPI::COMM_WORLD.Get_rank())
+	if(!MPI_COMM_WORLD.Get_rank())
 		cout << "Simulation started..." << endl;
 
 	// write initial bodies into file
@@ -585,7 +585,7 @@ int main(int argc, char** argv)
 		physicTime += simu->getDt();
 
 		// display the status of this iteration
-		if(Verbose && !MPI::COMM_WORLD.Get_rank())
+		if(Verbose && !MPI_COMM_WORLD.Get_rank())
 			cout << "Iteration n°" << setw(4) << iIte << " took "
 			     << setprecision(3) << std::fixed << setw(5) << perfIte.getElapsedTime() << " ms ("
 			     << setprecision(3) << std::fixed << setw(5) << perfIte.getGflops(simu->getFlopsPerIte())
@@ -595,13 +595,13 @@ int main(int argc, char** argv)
 		if(!RootOutputFileName.empty())
 			writeBodies<floatType>(simu, iIte);
 	}
-	if(Verbose && !MPI::COMM_WORLD.Get_rank())
+	if(Verbose && !MPI_COMM_WORLD.Get_rank())
 		cout << endl;
 
-	if(!MPI::COMM_WORLD.Get_rank())
+	if(!MPI_COMM_WORLD.Get_rank())
 		cout << "Simulation ended." << endl << endl;
 
-	if(!MPI::COMM_WORLD.Get_rank())
+	if(!MPI_COMM_WORLD.Get_rank())
 		cout << "Entire simulation took " << perfTotal.getElapsedTime() << " ms "
 		     << "(" << perfTotal.getGflops(simu->getFlopsPerIte() * (iIte -1)) << " Gflop/s)" << endl;
 
@@ -610,9 +610,9 @@ int main(int argc, char** argv)
 	delete simu;
 
 	if(NIterations > (iIte +1))
-		MPI::COMM_WORLD.Abort(0);
+		MPI_COMM_WORLD.Abort(0);
 
-	MPI::Finalize();
+	MPI_Finalize();
 
 	return EXIT_SUCCESS;
 }

--- a/src/murb/main.cpp
+++ b/src/murb/main.cpp
@@ -72,10 +72,18 @@ inline int  omp_get_thread_num (   ) { return 0; }
 #else
 #ifndef NO_MPI
 #define NO_MPI
-static inline int  MPI_get_rank (       ) { return 0;  };
-static inline int  MPI_get_size (       ) { return 1;  };
-static inline int  MPI_Barrier  (MPI_Comm comm)         {            };
-static inline int  MPI_Abort    (MPI_Comm comm int val) { exit(val); };
+class MPI_Comm {
+public:
+                          MPI_Comm     (       ) {            };
+       virtual            ~MPI_Comm    (       ) {            };
+};
+static MPI_Comm MPI_COMM_WORLD;
+static inline void MPI_Init(** argc, ***argv)            {}
+static inline void Finalize(                )            {}
+static inline int  MPI_get_rank (       )                { return 0;  };
+static inline int  MPI_get_size (       )                { return 1;  };
+static inline int  MPI_Barrier  (MPI_Comm comm)          {            };
+static inline int  MPI_Abort    (MPI_Comm comm, int val) { exit(val); };
 #endif
 #endif
 

--- a/src/murb/main.cpp
+++ b/src/murb/main.cpp
@@ -78,12 +78,12 @@ public:
        virtual            ~MPI_Comm    (       ) {            };
 };
 static MPI_Comm MPI_COMM_WORLD;
-static inline void MPI_Init(** argc, ***argv)            {}
-static inline void Finalize(                )            {}
-static inline int  MPI_get_rank (       )                { return 0;  };
-static inline int  MPI_get_size (       )                { return 1;  };
-static inline int  MPI_Barrier  (MPI_Comm comm)          {            };
-static inline int  MPI_Abort    (MPI_Comm comm, int val) { exit(val); };
+static inline void MPI_Init(int *argc, char  ***argv)    {}
+static inline void MPI_Finalize (       )                {}
+static inline int  MPI_get_rank (       )                { return 0;  }
+static inline int  MPI_get_size (       )                { return 1;  }
+static inline int  MPI_Barrier  (MPI_Comm comm)          { return 0;  }
+static inline int  MPI_Abort    (MPI_Comm comm, int val) { exit(val); return 0; }
 #endif
 #endif
 


### PR DESCRIPTION
Closes #1 :
Replaced all C++ bindings with C ones.
Not sure the creation of `MPI_get_rank` and `MPI_get_size` suits the standards. I wonder what's the best spot where to put them. I mainly created these 2 functions because of constructors of `SimulationNBodyMPI` and the fact that `MPI_Comm_get_rank/size` returns value with references. 